### PR TITLE
検索した際のCPU高負荷の問題を修正

### DIFF
--- a/app/src/main/java/com/example/meishizukan/activity/SearchPersonViewActivity.kt
+++ b/app/src/main/java/com/example/meishizukan/activity/SearchPersonViewActivity.kt
@@ -230,8 +230,13 @@ class SearchPersonViewActivity : AppCompatActivity() {
 
             //ローディング画面(view)までスクロールされたら一番下までスクロールし、ロック
             if(personListLinearLayout.bottom - loadingItem.height
-                <= personListScrollView.height + personListScrollView.scrollY){
+                <= personListScrollView.height + personListScrollView.scrollY
+                && !scrollViewIsLocked){
+
+                showLoadingItem()
+
                 personListScrollView.smoothScrollBy(0,loadingItem.height)
+
                 lockScrollView()
             }
 
@@ -390,6 +395,14 @@ class SearchPersonViewActivity : AppCompatActivity() {
         rootConstraintLayout.bringToFront()
         loadingDialogView.visibility = View.INVISIBLE
         window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE) //タッチ無効化解除
+    }
+
+    /*
+    * 人物リストビューのローディングアイテムを表示
+    * */
+    private fun showLoadingItem(){
+        val loadingItem = personListLinearLayout.findViewById<LinearLayout>(R.id.rootLinearLayout)
+        loadingItem.visibility = View.VISIBLE
     }
 
     /*

--- a/app/src/main/res/layout/person_listview_loading_item.xml
+++ b/app/src/main/res/layout/person_listview_loading_item.xml
@@ -3,7 +3,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:visibility="invisible">
 
     <ProgressBar
         android:id="@+id/progressBar"


### PR DESCRIPTION
人物リストビューに表示していたローディングアイテムが画面上見えてなくても
仕事していたためにcpuが使われていた。デフォルト非表示で、ローディングアイテムが見える位置までスクロールされたら表示するように処理を記述