### PR TITLE
重い処理を非同期処理

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     implementation 'com.google.android.gms:play-services-ads:19.0.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'junit:junit:4.12'
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.27.0-eap13"
 }

--- a/app/src/main/java/com/example/meishizukan/activity/AllPhotosViewActivity.kt
+++ b/app/src/main/java/com/example/meishizukan/activity/AllPhotosViewActivity.kt
@@ -2,7 +2,6 @@ package com.example.meishizukan.activity
 
 import android.app.Activity
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.database.sqlite.SQLiteDatabase
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
@@ -15,7 +14,6 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.example.meishizukan.R
 import com.example.meishizukan.dto.Photo
-import com.example.meishizukan.util.BitmapUtils.convertBinaryToBitmap
 import com.example.meishizukan.util.DateUtils.getDay
 import com.example.meishizukan.util.DateUtils.getMonth
 import com.example.meishizukan.util.DateUtils.getYear
@@ -199,8 +197,8 @@ class AllPhotosViewActivity : AppCompatActivity() {
     * */
     private fun showLoadingDialog(){
         window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE) //タッチ無効化
-        loadingDialogView.bringToFront()
-        loadingDialogView.visibility = View.VISIBLE
+        loadingAnimationView.bringToFront()
+        loadingAnimationView.visibility = View.VISIBLE
     }
 
     /*
@@ -208,7 +206,7 @@ class AllPhotosViewActivity : AppCompatActivity() {
     * */
     private fun hideLoadingDialog(){
         rootConstraintLayout.bringToFront()
-        loadingDialogView.visibility = View.INVISIBLE
+        loadingAnimationView.visibility = View.INVISIBLE
         window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE) //タッチ無効化解除
     }
 

--- a/app/src/main/java/com/example/meishizukan/activity/SearchPersonViewActivity.kt
+++ b/app/src/main/java/com/example/meishizukan/activity/SearchPersonViewActivity.kt
@@ -2,7 +2,6 @@ package com.example.meishizukan.activity
 
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ActivityInfo
 import android.database.sqlite.SQLiteDatabase
 import android.graphics.Rect
 import androidx.appcompat.app.AppCompatActivity
@@ -35,7 +34,6 @@ import com.example.meishizukan.util.*
 import com.example.meishizukan.util.PhoneticName.hiraganaToKatakana
 import com.google.android.gms.ads.RequestConfiguration
 import junit.framework.TestCase.assertEquals
-import kotlinx.android.synthetic.main.activity_photos_view.*
 import kotlinx.android.synthetic.main.activity_search_person_view.adView
 import kotlinx.android.synthetic.main.activity_search_person_view.deleteButton
 import kotlinx.android.synthetic.main.activity_search_person_view.footerOptionBar
@@ -302,6 +300,9 @@ class SearchPersonViewActivity : AppCompatActivity() {
             search()
         }
 
+        val progressTextView = loadingAnimationView.findViewById<TextView>(R.id.progressTextView)
+        progressTextView?.text = getString(R.string.progress_text_on_search)
+
         //すべての写真リンク、写真、人物を削除
         writableDb.delete("photos_links","_id <> 10000",null)
         writableDb.delete("photos","_id <> 10000",null)
@@ -405,8 +406,8 @@ class SearchPersonViewActivity : AppCompatActivity() {
     * */
     private fun showLoadingDialog(){
         window.addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE) //タッチ無効化
-        loadingDialogView.bringToFront()
-        loadingDialogView.visibility = View.VISIBLE
+        loadingAnimationView.bringToFront()
+        loadingAnimationView.visibility = View.VISIBLE
     }
 
     /*
@@ -414,7 +415,7 @@ class SearchPersonViewActivity : AppCompatActivity() {
     * */
     private fun hideLoadingDialog(){
         rootConstraintLayout.bringToFront()
-        loadingDialogView.visibility = View.INVISIBLE
+        loadingAnimationView.visibility = View.INVISIBLE
         window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE) //タッチ無効化解除
     }
 

--- a/app/src/main/res/drawable/circle.xml
+++ b/app/src/main/res/drawable/circle.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rotate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="2000"
+    android:fromDegrees="0"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:toDegrees="360" >
+    <shape
+        android:innerRadius="18dp"
+        android:shape="ring"
+        android:thickness="5dp"
+        android:useLevel="false" >
+        <size
+            android:height="48dp"
+            android:width="48dp" />
+
+        <gradient
+            android:centerColor="#802A67AD"
+            android:centerY="0.5"
+            android:endColor="#ff2A67AD"
+            android:startColor="#002A67AD"
+            android:type="sweep"
+            android:useLevel="false" />
+    </shape>
+</rotate>

--- a/app/src/main/res/layout/activity_all_photos_view.xml
+++ b/app/src/main/res/layout/activity_all_photos_view.xml
@@ -281,8 +281,8 @@
         app:layout_constraintStart_toStartOf="parent"></com.google.android.gms.ads.AdView>
 
     <include
-        android:id="@+id/loadingDialogView"
-        layout="@layout/loading_dialog_fill_parent"
+        android:id="@+id/loadingAnimationView"
+        layout="@layout/full_screen_loading_item"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="invisible"

--- a/app/src/main/res/layout/activity_photos_view.xml
+++ b/app/src/main/res/layout/activity_photos_view.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootConstraintLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#ECECEC"
@@ -349,6 +350,17 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"></com.google.android.gms.ads.AdView>
+
+    <include
+        android:id="@+id/loadingAnimationView"
+        layout="@layout/full_screen_loading_item"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/fullScreenView"

--- a/app/src/main/res/layout/activity_search_person_view.xml
+++ b/app/src/main/res/layout/activity_search_person_view.xml
@@ -338,8 +338,8 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <include
-        android:id="@+id/loadingDialogView"
-        layout="@layout/loading_dialog_fill_parent"
+        android:id="@+id/loadingAnimationView"
+        layout="@layout/full_screen_loading_item"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="invisible"/>

--- a/app/src/main/res/layout/full_screen_loading_item.xml
+++ b/app/src/main/res/layout/full_screen_loading_item.xml
@@ -9,16 +9,19 @@
     <ProgressBar
         android:id="@+id/progressBar"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:indeterminateDrawable="@drawable/circle" />
 
     <TextView
-        android:id="@+id/pbText"
+        android:id="@+id/progressTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textStyle="bold"
-        android:gravity="center"
-        android:textColor="@color/loadingDialogTextColor"
         android:layout_marginTop="8dp"
-        android:text="@string/loading_dialog_text"/>
+        android:fontFamily="@font/source_han_serif_regular"
+        android:gravity="center"
+        android:text="@string/default_progress_text"
+        android:textColor="@color/loadingDialogTextColor"
+        android:textSize="20sp"
+        android:textStyle="bold" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/person_listview_loading_item.xml
+++ b/app/src/main/res/layout/person_listview_loading_item.xml
@@ -9,15 +9,16 @@
     <ProgressBar
         android:id="@+id/progressBar"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:indeterminateDrawable="@drawable/circle" />
 
     <TextView
-        android:id="@+id/pbText"
+        android:id="@+id/progressTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:gravity="center"
-        android:text="@string/loading_dialog_text"
+        android:text="@string/default_progress_text"
         android:textColor="@color/loadingDialogTextColor"
         android:textStyle="bold" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="empty">--  --  --  --</string>
 
     <!-- 人物検索画面 -->
+    <string name="progress_text_on_search">人物を読み込み中…</string>
     <string name="search_edittext_hint">人物を検索</string>
     <string name="no_persons_text">人物が登録されていません。</string>
     <string name="no_results_textview_text">該当する人物はいませんでした。</string>
@@ -11,7 +12,7 @@
     <string name="message_on_click_all_photos_view_button">実装予定です</string>
 
     <!-- ローディング画面 -->
-    <string name="loading_dialog_text">Loading</string>
+    <string name="default_progress_text">読み込み中…</string>
 
     <!-- NavigationDrawerメニュー -->
     <string name="search_person_view">人物を検索</string>
@@ -61,6 +62,8 @@
     <string name="message_on_failed_add_photos">同じ写真が既に追加されていました</string>
     <string name="message_on_failed_open_camera">権限がないのでカメラを起動できませんでした</string>
     <string name="message_on_no_camera_app">カメラアプリがありません</string>
+    <string name="progress_text_on_add_photos">写真を読み込み中…</string>
+    <string name="message_on_click_back_button">処理が正常に終了するまでもうしばらくお待ちください</string>
 
     <!-- 50音のア段 -->
     <string-array name="japanese_syllabary_regex">

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+kotlin.coroutines=enable


### PR DESCRIPTION
ギャラリーから3MB程度の高画質な写真を追加しようとすると、ギャラリーのインテントが終了する際に一時的なブラックアウトが発生する。また、CPUも高負荷であった。UIスレッドの負荷を下げるために写真の取得や、ファイル保存は外部スレッドで実行する